### PR TITLE
Add `#ifndef` guards for `INLINE` & `UNUSED`

### DIFF
--- a/src/noftypes.h
+++ b/src/noftypes.h
@@ -41,18 +41,26 @@
 #define HOST_LITTLE_ENDIAN
 
 #ifdef __GNUC__
+#ifndef INLINE
 #define INLINE static inline
+#endif
 #define ZERO_LENGTH 0
 #elif defined(WIN32)
+#ifndef INLINE
 #define INLINE static __inline
+#endif
 #define ZERO_LENGTH 0
 #else /* crapintosh? */
+#ifndef INLINE
 #define INLINE static
+#endif
 #define ZERO_LENGTH 1
 #endif
 
 /* quell stupid compiler warnings */
+#ifndef UNUSED
 #define UNUSED(x) ((x) = (x))
+#endif
 
 typedef signed char int8;
 typedef signed short int16;


### PR DESCRIPTION
This PR fixes a bunch of annoying warnings about `INLINE` and `UNUSED` being "previously defined in Arduino GFX Library" when using it together with Nofrendo library.