### PR TITLE
fix load pal color palette

### DIFF
--- a/src/nes/nes.c
+++ b/src/nes/nes.c
@@ -478,7 +478,7 @@ int nes_insertcart(const char *filename, nes_t *machine)
    nes6502_setcontext(machine->cpu);
 
    /* rom file */
-   machine->rominfo = rom_load(filename);
+   machine->rominfo = rom_load(filename, machine->ppu);
    if (NULL == machine->rominfo)
       goto _fail;
 

--- a/src/nes/nes_rom.c
+++ b/src/nes/nes_rom.c
@@ -195,7 +195,7 @@ static int rom_loadrom(FILE *fp, rominfo_t *rominfo)
 }
 
 /* If we've got a VS. system game, load in the palette, as well */
-static void rom_checkforpal(rominfo_t *rominfo)
+static void rom_checkforpal(rominfo_t *rominfo, ppu_t *ppu)
 {
    FILE *fp;
    rgb_t vs_pal[64];
@@ -222,7 +222,8 @@ static void rom_checkforpal(rominfo_t *rominfo)
    /* TODO: this should really be a *SYSTEM* flag */
    rominfo->flags |= ROM_FLAG_VERSUS;
    /* TODO: bad, BAD idea, calling nes_getcontextptr... */
-   ppu_setpal(nes_getcontextptr()->ppu, vs_pal);
+   // ppu_setpal(nes_getcontextptr()->ppu, vs_pal);
+   ppu_setpal(ppu, vs_pal);
    nofrendo_log_printf("Game specific palette found -- assuming VS. UniSystem\n");
 }
 
@@ -418,7 +419,7 @@ char *rom_getinfo(rominfo_t *rominfo)
 }
 
 /* Load a ROM image into memory */
-rominfo_t *rom_load(const char *filename)
+rominfo_t *rom_load(const char *filename, ppu_t *ppu)
 {
    FILE *fp;
    rominfo_t *rominfo;
@@ -472,7 +473,7 @@ rominfo_t *rom_load(const char *filename)
    rom_loadsram(rominfo);
 
    /* See if there's a palette we can load up */
-   rom_checkforpal(rominfo);
+   rom_checkforpal(rominfo, ppu);
 
    gui_sendmsg(GUI_GREEN, "ROM loaded: %s", rom_getinfo(rominfo));
 

--- a/src/nes/nes_rom.h
+++ b/src/nes/nes_rom.h
@@ -27,7 +27,7 @@
 #define _NES_ROM_H_
 
 #include <unistd.h>
-
+#include "nes_ppu.h"
 #include "../osd.h"
 
 typedef enum
@@ -62,7 +62,7 @@ typedef struct rominfo_s
 } rominfo_t;
 
 extern int rom_checkmagic(const char *filename);
-extern rominfo_t *rom_load(const char *filename);
+extern rominfo_t *rom_load(const char *filename, ppu_t *ppu);
 extern void rom_free(rominfo_t **rominfo);
 extern char *rom_getinfo(rominfo_t *rominfo);
 


### PR DESCRIPTION
If you put a ".pal" file next to the ".nes" file, the error "Guru Meditation Error: Core 0 panic'ed (StoreProhibited). Exception was unhandled." (when using ESP32). The reason is the incorrect sequence of using the variable "static nes_t nes;"